### PR TITLE
[PLAT-319] Updated GitHub Actions

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -27,15 +27,15 @@ runs:
 
   steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "3.8"
 
     - name: Set up AWS creds
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v1-node16
       with:
         role-to-assume: ${{ inputs.role-to-assume-arn }}
         aws-region: eu-west-2


### PR DESCRIPTION
Updated GitHub actions to solve the following deprecation alerts:

- Node.js 12 actions are deprecated
- The set-output/save-state command is deprecated