### PR TITLE
Add missing parameter to README and correct input description

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Pull in the action in your workflow as below, making sure to specify the release
     container-sign-kms-key-arn: ${{ secrets.SIGNING_PROFILE_NAME }}
     working-directory: ./sam-ecr-app
     template-file: custom-template.yaml
-    role-to-assume-arn: ${{ secrets.ROLE_TO_ASSUME }}}
+    role-to-assume-arn: ${{ secrets.ROLE_TO_ASSUME }}
+    ecr-repo-name: ${{ secrets.ECR_REPO_NAME }}
 ```
 
 ## Requirements

--- a/action.yaml
+++ b/action.yaml
@@ -13,13 +13,13 @@ inputs:
     required: false
     default: template.yaml
   working-directory:
-    description: "The working directory containing the  app"
+    description: "The working directory containing the app"
     required: false
   artifact-bucket-name:
     description: "The secret with the name of the artifact S3 bucket (required) eg secrets.ARTIFACT_BUCKET_NAME"
     required: true
   ecr-repo-name:
-    description: "The secret with the name of the ECR Repo (required)  eg secrets.ecr_repo_NAME"
+    description: "The secret with the name of the ECR Repo (required) eg secrets.ECR_REPO_NAME"
     required: true
 
 runs:


### PR DESCRIPTION
Added missing required parameter in the README example, and made capitalisation consistent in input description