### PR TITLE
[PLAT-274] secrets names inline with user guide

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -1,0 +1,14 @@
+---
+# See: https://commitlint.js.org/#/reference-rules
+rules:
+  body-leading-blank: [2, 'always']
+  footer-leading-blank: [2, 'always']
+  header-case: [1, 'always', 'sentence-case']
+  header-full-stop: [2, 'never']
+  header-max-length: [2, 'always', 50]
+  references-empty: [1, 'never']
+  trailer-exists: [1, 'always', 'Co-authored-by:']
+parserPreset:
+  parserOpts:
+    # sets the prefix that references-empty will look for
+    issuePrefixes: ['PLAT-']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,24 @@ repos:
                      ^Pipfile/|
                      ^pyproject.toml
               )
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.1.13
+    hooks:
+      - id: remove-tabs
+      - id: remove-crlf
+  - repo: https://github.com/mattlqx/pre-commit-search-and-replace
+    rev: v1.0.5
+    hooks:
+      - id: search-and-replace
+        stages: [commit-msg, commit]
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v8.0.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        args: ['--verbose']
+        verbose: true
+  - repo: https://github.com/lovesegfault/beautysh
+    rev: 'v6.2.1'
+    hooks:
+      - id: beautysh

--- a/.pre-commit-search-and-replace.yaml
+++ b/.pre-commit-search-and-replace.yaml
@@ -1,0 +1,5 @@
+---
+- search: /artefact/
+  insensitive: true
+  description: >
+    British spelling of "artefact" is not used, use "artifact" instead.

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ Pull in the action in your workflow as below, making sure to specify the release
 - name: Deploy SAM app to ECR
   uses: alphagov/di-devplatform-upload-action-ecr@<version_number>
   with:
-    artifact-bucket-name: ${{ secrets.ARTIFACT_BUCKET_NAME }}
-    container-sign-kms-key-arn: ${{ secrets.SIGNING_PROFILE_NAME }}
+    artifact-bucket-name: ${{ secrets.ARTIFACT_SOURCE_BUCKET_NAME }}
+    container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
     working-directory: ./sam-ecr-app
     template-file: custom-template.yaml
-    role-to-assume-arn: ${{ secrets.ROLE_TO_ASSUME }}
-    ecr-repo-name: ${{ secrets.ECR_REPO_NAME }}
+    role-to-assume-arn: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
+    ecr-repo-name: ${{ secrets.ECR_REPOSITORY }}
 ```
 
 ## Requirements

--- a/action.yaml
+++ b/action.yaml
@@ -3,10 +3,10 @@ description: "Packages and uploads, replaces reference in (eg) template.yaml"
 inputs:
 
   role-to-assume-arn:
-    description: "The secret with the ARN of the role to assume (required) eg secrets.ROLE_TO_ASSUME_ARN"
+    description: "The secret with the ARN of the role to assume (required) eg secrets.GH_ACTIONS_ROLE_ARN"
     required: true
   container-sign-kms-key-arn:
-    description: "The secret with the ARN of the key to sign container images"
+    description: "The secret with the ARN of the key to sign container images e.g. secrets.CONTAINER_SIGN_KMS_KEY"
     required: true
   template-file:
     description: "The name of the CF template for the application. This defaults to template.yaml"
@@ -16,10 +16,10 @@ inputs:
     description: "The working directory containing the app"
     required: false
   artifact-bucket-name:
-    description: "The secret with the name of the artifact S3 bucket (required) eg secrets.ARTIFACT_BUCKET_NAME"
+    description: "The secret with the name of the artifact S3 bucket (required) eg secrets.ARTIFACT_SOURCE_BUCKET_NAME"
     required: true
   ecr-repo-name:
-    description: "The secret with the name of the ECR Repo (required) eg secrets.ECR_REPO_NAME"
+    description: "The secret with the name of the ECR Repo (required) eg secrets.ECR_REPOSITORY"
     required: true
 
 runs:

--- a/scripts/build-tag-push-ecr.sh
+++ b/scripts/build-tag-push-ecr.sh
@@ -16,10 +16,10 @@ sam build --template-file="$TEMPLATE_FILE"
 mv .aws-sam/build/template.yaml cf-template.yaml
 
 if grep -q "CONTAINER-IMAGE-PLACEHOLDER" cf-template.yaml; then
-  echo "Replacing \"CONTAINER-IMAGE-PLACEHOLDER\" with new ECR image ref"
-  sed -i "s|CONTAINER-IMAGE-PLACEHOLDER|$ECR_REGISTRY/$ECR_REPO_NAME:$GITHUB_SHA|" cf-template.yaml
+    echo "Replacing \"CONTAINER-IMAGE-PLACEHOLDER\" with new ECR image ref"
+    sed -i "s|CONTAINER-IMAGE-PLACEHOLDER|$ECR_REGISTRY/$ECR_REPO_NAME:$GITHUB_SHA|" cf-template.yaml
 else
-  echo "WARNING!!! Image placeholder text \"CONTAINER-IMAGE-PLACEHOLDER\" not found - uploading template anyway"
+    echo "WARNING!!! Image placeholder text \"CONTAINER-IMAGE-PLACEHOLDER\" not found - uploading template anyway"
 fi
 zip template.zip cf-template.yaml
 aws s3 cp template.zip "s3://$ARTIFACT_BUCKET_NAME/template.zip" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA"


### PR DESCRIPTION
Ensuring the secret names used in this GHA documentation matches https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3107258369/How+to+deploy+a+container+to+Fargate+with+secure+pipelines . Also added pre-commit beautysh, commitlint and search-and-replace hooks

Issue: PLAT-274
Co-authored-by: