### PR TITLE
PLAT-1795: container-sign-kms-key now not required

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 default_stages: [commit]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.4.0
     hooks:
       - id: detect-private-key
       - id: detect-aws-credentials
@@ -17,8 +17,8 @@ repos:
     hooks:
       - id: detect-secrets
         args: ['--baseline', '.secrets.baseline']
-        exclude: .*/keys/.*|
-              (?x)(
+        exclude: (?x)(
+                    .*/keys/.*|
                      ^package-lock.json$/|
                      ^Pipfile/|
                      ^pyproject.toml

--- a/CHANGLOG.md
+++ b/CHANGLOG.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+This is a manually updated Changelog and new Changes should be added below as `## [version] - DATE`,
+and still follows the `MAJOR`, `MINOR`, & `PATCH` convention.
+
+See [here](https://keepachangelog.com/en/1.1.0/#how) for a list of `Types of changes` labels.
+
+## [v1.0.0] - 2023-06-29
+### Added
+- Initial release

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Description
+
+### Ticket number
+[PLAT-XXX]
+## Checklist
+
+- [ ] I have updated the changelog
+
+- [ ] I have tested this and added output to Jira
+**_Comment:_**
+
+- [ ] Documentation added ([link]())
+**_Comment:_**
+
+### Co-authored by

--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ The action packages, signs, and uploads the application to the specified ECR and
 | Input                      | Required | Description                                                                            | Example                                                                              |
 |----------------------------|----------|----------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
 | artifact-bucket-name       | true     | The secret with the name of the artifact S3 bucket                                     | artifact-bucket-1234                                                                 |
-| container-sign-kms-key-arn | true     | The secret with the name of the Signing Profile resource in AWS                        | signing-profile-1234                                                                 |
+| container-sign-kms-key-arn | false     | The secret with the name of the Signing Profile resource in AWS                        | signing-profile-1234                                                                 |
 | working-directory          | false    | The working directory containing the SAM app and the template file                     | ./sam-ecr-app                                                                        |
 | template-file              | false    | The name of the CF template for the application. This defaults to template.yaml        | custom-template.yaml                                                                 |
 | role-to-assume-arn         | true     | The secret with the GitHub Role ARN from the pipeline stack                            | arn:aws:iam::0123456789999:role/myawesomeapppipeline-GitHubActionsRole-16HIKMTBBDL8Y |
 | ecr-repo-name              | true     | The secret with the name of the ECR repo created by the app-container-repository stack | app-container-repository-tobytraining-containerrepository-i6gdfkdnwrrm               |
-
+| dockerfile                 | false     | The Dockerfile to use for the build | Dockerfile
+| checkout-repo                 | false     | Checks out the repo as the first step of the action. Default "true". | "true"
 
 ## Usage Example
 
@@ -43,9 +44,7 @@ Pull in the action in your workflow as below, making sure to specify the release
 
 ## Releasing updates
 
-We
-follow [recommended best practices](https://docs.github.com/en/actions/creating-actions/releasing-and-maintaining-actions)
-for releasing new versions of the action.
+We follow [recommended best practices](https://docs.github.com/en/actions/creating-actions/releasing-and-maintaining-actions) for releasing new versions of the action.
 
 ### Non-breaking changes
 

--- a/action.yaml
+++ b/action.yaml
@@ -6,7 +6,8 @@ inputs:
     required: true
   container-sign-kms-key-arn:
     description: "The secret with the ARN of the key to sign container images e.g. secrets.CONTAINER_SIGN_KMS_KEY"
-    required: true
+    required: false
+    default: "none"
   template-file:
     description: "The name of the CF template for the application. This defaults to template.yaml"
     required: false
@@ -14,7 +15,6 @@ inputs:
   working-directory:
     description: "The working directory containing the app"
     required: false
-    default: .
   artifact-bucket-name:
     description: "The secret with the name of the artifact S3 bucket (required) eg secrets.ARTIFACT_SOURCE_BUCKET_NAME"
     required: true
@@ -25,10 +25,6 @@ inputs:
     description: The Dockerfile to use for the build
     required: false
     default: Dockerfile
-  docker-build-path:
-    description: The Dockerfile path to use for the build
-    required: false
-    default: .
   checkout-repo:
     description: Checks out the repo as the first step of the action. Default "true".
     required: false


### PR DESCRIPTION
## Description

Updating `action.yaml` & `build-tag-push-ecr.sh`
- Removed docker-build-path
- Updated sam build command
- `container-sign-kms-key-arn` is no longer required and will default to none if a value is not presented.
- Added changelog.md
- Added PR template
- Fixed pre-commit

Passing workflow: https://github.com/alphagov/di-devplatform-demo-sam-app/actions/runs/5403471767/jobs/9816324290
![Screenshot 2023-06-28 at 17 24 04](https://github.com/alphagov/di-devplatform-upload-action-ecr/assets/117449945/22a34d5a-22cf-4ac9-bcdc-d1449acb8f7c)


### Ticket number
[PLAT-1795: CRI Orange : New feature request | di-devplatform-upload-action-ecr needs updating](https://govukverify.atlassian.net/browse/PLAT-1795)
## Checklist

- [ ] I have tested this and added output to Jira
**_Comment:_**

- [ ] Documentation added ([link]())
**_Comment:_**

### Co-authored by