### PR TITLE
Plat 1795: Fix to bring back the DOCKER_BUILD_PATH functionality 

### DIFF
--- a/CHANGLOG.md
+++ b/CHANGLOG.md
@@ -9,6 +9,10 @@ and still follows the `MAJOR`, `MINOR`, & `PATCH` convention.
 
 See [here](https://keepachangelog.com/en/1.1.0/#how) for a list of `Types of changes` labels.
 
+## [v1.0.1] - 2023-06-29
+### Added
+- Added the ability to use a docker file outside of the working directory functionality back in
+
 ## [v1.0.0] - 2023-06-29
 ### Added
 - Initial release

--- a/action.yaml
+++ b/action.yaml
@@ -15,6 +15,7 @@ inputs:
   working-directory:
     description: "The working directory containing the app"
     required: false
+    default: .
   artifact-bucket-name:
     description: "The secret with the name of the artifact S3 bucket (required) eg secrets.ARTIFACT_SOURCE_BUCKET_NAME"
     required: true
@@ -25,6 +26,9 @@ inputs:
     description: The Dockerfile to use for the build
     required: false
     default: Dockerfile
+  docker-build-path:
+    description: The Dockerfile path to use for the build
+    required: false
   checkout-repo:
     description: Checks out the repo as the first step of the action. Default "true".
     required: false


### PR DESCRIPTION
## Description
Fix for removing the DOCKER_BUILD_PATH functionality (that didn't work) 

Evidence of using both the `working-directory` path and the `docker-build-path`
<img width="874" alt="Screenshot 2023-06-30 at 13 24 48" src="https://github.com/alphagov/di-devplatform-upload-action-ecr/assets/117449945/8c5c800d-f662-4dc5-ba2d-b875b2aeac93">

<img width="835" alt="Screenshot 2023-06-30 at 13 20 22" src="https://github.com/alphagov/di-devplatform-upload-action-ecr/assets/117449945/d170241e-741f-4a8b-807a-3cf276d320b1">

### Ticket number
[PLAT-1795]
## Checklist

- [ ] I have updated the changelog

- [ ] I have tested this and added output to Jira
**_Comment:_**

- [ ] Documentation added ([link]())
**_Comment:_**

### Co-authored by

[PLAT-1795]: https://govukverify.atlassian.net/browse/PLAT-1795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ